### PR TITLE
Update requirements.txt for Django 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow
-Django
+Django==1.8
 django-auth-ldap==1.2.7
 pytz
 pyyaml


### PR DESCRIPTION
Django 1.9 gives a compile error, Django 1.8 seems to works fine.

*** Error compiling '/srv/.virtualenvs/panopuppet/build/Django/django/conf/app_template/apps.py'...
  File "/srv/.virtualenvs/panopuppet/build/Django/django/conf/app_template/apps.py", line 1
    {{ unicode_literals }}from django.apps import AppConfig
                             ^
SyntaxError: invalid syntax