### PR TITLE
Update requirements.txt django-auth-ldap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.6
-django-auth-ldap==1.2.5
+django-auth-ldap==1.2.7
 git+https://github.com/rbarrois/python-ldap.git@py3
 pytz==2014.10
 requests==2.5.1


### PR DESCRIPTION
django-auth-ldap==1.2.5 doesn't compile with python3  (SC rh-python34).
django-auth-ldap==1.2.7 does work.