### PR TITLE
Update requirements.txt for Django 1.8.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow
-Django==1.8
+Django==1.8.8
 django-auth-ldap==1.2.7
 pytz
 pyyaml


### PR DESCRIPTION
Noticed that `Django==1.8` doesn't get the latest release from 1.8.x, so 1.8 is 'pretty old'.
Saw on the Django website 1.8.8 was also just released.